### PR TITLE
Long keywords

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# gtrendsR 1.3.4 (Unreleased)
+
+- Fixing crash occuring when monthly data was returned (#81).
+
+- `gtrends()` will throw a warning if data is returned monthly (#80).
+
 # gtrendsR 1.3.3
 
 - A ggplot2 object can now be returned for further customization. `plot(gtrends("NHL")) + ggtitle("NHL trend") + theme(legend.position="none")`

--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -519,6 +519,8 @@ as.zoo.gtrends <- function(x, ...) {
       weeks <- as.POSIXct(paste(weeks[, 1], "-01", sep = ""))
       weeks <- data.frame(start = weeks)
       
+      warning("Data was returned monthly.", call. = FALSE)
+      
     }else if(nchar(weeks$date[1]) == 10){
       
       weeks <- as.POSIXct(weeks$date)
@@ -541,47 +543,34 @@ as.zoo.gtrends <- function(x, ...) {
   # Section to deal with geographical data
   #---------------------------------------------------------------------
   
-  ## block 3+: geographical info
-  start <- 3 # Always start at index 3
+  # Data likely returned monthly, so no geographical information.
+  blocks <- NULL
   
-  blocks <- lapply(start:length(vec), function(i)
-    read.csv(
-      textConnection(strsplit(vec[i], "\\\n")[[1]]),
-      skip = 1,
-      stringsAsFactors = FALSE
-    ))
-  
-  
-  blocks <- Map(assign, 
-                make.names(headers[start:length(headers)]), 
-                value = blocks)
+  if(length(vec) >= 3) {
+    
+    ## block 3+: geographical info
+    start <- 3 # Always start at index 3
+    
+    blocks <- lapply(start:length(vec), function(i)
+      read.csv(
+        textConnection(strsplit(vec[i], "\\\n")[[1]]),
+        skip = 1,
+        stringsAsFactors = FALSE
+      ))
+    
+    
+    blocks <- Map(assign, 
+                  make.names(headers[start:length(headers)]), 
+                  value = blocks)
+  }
   
   res <- list(query = queryparams,
               meta = meta,
               trend = trend,
               headers = headers)
 
-  
   res <- append(res, blocks)
-                
- 
-  # res <- list(
-  #   
-  #   query = queryparams,
-  #   meta = meta,
-  #   
-  #   trend = trend,
-  #   
-  #   regions = res[which(types == "State" | types == "Province")],
-  #   topmetros = res[which(types == "DMA Region")],
-  #   cities = res[which(types == "City")],
-  #   
-  #   # searches = schlist,
-  #   # rising = rislist,
-  #   
-  #   headers = headers
-  # )
-  
+
   # if data was returned monthly, it will not be possible to plot maps
   res[lapply(res, length) == 0]  <- NA
   

--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -494,10 +494,15 @@ as.zoo.gtrends <- function(x, ...) {
                       stringsAsFactors = FALSE)
   
   trend <- trend[, mapply(is.numeric, trend), drop = FALSE]
-  
-  #names(trend) <- unlist(strsplit(queryparams[1], ","), use.names = FALSE)
-  
+
+  # For some reason, the headers returned by Google will be the country names
+  # if only 1 keeword is provided. 
   kw <- trimws(unlist(strsplit(queryparams[1], ","), use.names = FALSE))
+  
+  if(length(kw) > 1){
+    kw <- trimws(names(trend))
+  }
+  
   geo <- trimws(unlist(strsplit(queryparams[3], ","), use.names = FALSE))
   names(trend) <- make.names(paste(kw, geo))
   


### PR DESCRIPTION
This was crashing before. Looks like Google will sometimes remove keywords from the returned data.

```r
head(gtrends(c("cat", "flood risk management"), geo = "GB")$trend)
```

https://www.google.fr/trends/explore#q=cat%2C%20flood%20risk%20management&geo=GB&cmpt=q&tz=Etc%2FGMT-1
