### PR TITLE
adding columns with NA values when requested kw are not returned

### DIFF
--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -464,7 +464,7 @@ as.zoo.gtrends <- function(x, ...) {
 .processResults <- function(resultsText, queryparams) {
   
   #get back to latin1 encoding
-  #queryparams[1] <- iconv(queryparams[1], "utf-8", "latin1", sub = "byte")
+  queryparams[1] <- iconv(queryparams[1], "utf-8", "latin1", sub = "byte")
   
   vec <- strsplit(resultsText, "\\\n{2,}")[[1]]
   

--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -464,7 +464,7 @@ as.zoo.gtrends <- function(x, ...) {
 .processResults <- function(resultsText, queryparams) {
   
   #get back to latin1 encoding
-  queryparams[1] <- iconv(queryparams[1], "utf-8", "latin1", sub = "byte")
+  #queryparams[1] <- iconv(queryparams[1], "utf-8", "latin1", sub = "byte")
   
   vec <- strsplit(resultsText, "\\\n{2,}")[[1]]
   
@@ -497,10 +497,10 @@ as.zoo.gtrends <- function(x, ...) {
 
   # For some reason, the headers returned by Google will be the country names
   # if only 1 keeword is provided. 
-  requested_kw <- trimws(unlist(strsplit(queryparams[1], ","), use.names = FALSE))
-  received_kw <- trimws(names(trend))
+  requested_kw <- tolower(trimws(unlist(strsplit(queryparams[1], ","), use.names = FALSE)))
+  received_kw <- tolower(trimws(names(trend)))
 
-  if(length(requested_kw > 1) & !identical(requested_kw, received_kw)) {
+  if(length(requested_kw) > 1 & (length(requested_kw) != length(received_kw))) {
     
     missing_kw <- requested_kw[!requested_kw %in% received_kw]
     
@@ -509,14 +509,14 @@ as.zoo.gtrends <- function(x, ...) {
                   "keyword(s)."),
             call. = FALSE)
     
-    # Dirk, do you think we should add columns missing keywords with NA values?
+    trend[, missing_kw] <- NA
   }
   
-  kw <- ifelse(length(requested_kw) == 1, requested_kw, received_kw)
+  requested_kw <- make.names(requested_kw)
   
   geo <- trimws(unlist(strsplit(queryparams[3], ","), use.names = FALSE))
   
-  names(trend) <- make.names(paste(kw, geo))
+  names(trend) <- make.names(paste(requested_kw, geo))
   
   if(ncol(weeks) == 2){
     
@@ -553,7 +553,8 @@ as.zoo.gtrends <- function(x, ...) {
   
   trend <- cbind(weeks, trend)
   
-  trend <- na.omit(trend)
+  # Remove lines with all NA (happens sometimes to the last line of the df)
+  trend <- trend[!apply(trend, 1, function(x) all(is.na(x))), ]
   
   #---------------------------------------------------------------------
   # Section to deal with geographical data


### PR DESCRIPTION
```r
> head(gtrends(c("cat", "flood risk management"), geo = "GB")$trend)
       start        end cat.GB flood.risk.management.GB
1 2004-01-04 2004-01-10     48                       NA
2 2004-01-11 2004-01-17     43                       NA
3 2004-01-18 2004-01-24     44                       NA
4 2004-01-25 2004-01-31     44                       NA
5 2004-02-01 2004-02-07     41                       NA
6 2004-02-08 2004-02-14     44                       NA
Warning message:
No data returned for 'flood risk management' keyword(s). 
```