### PR TITLE
fallback for google.{user,password} (closes #121)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - Fixing a bug where overriding `countries` variable was breaking package's functionalities (#109).
 
+- Correct default fallback for querying for google.user and google.password in gconnect (#121)
+
 # gtrendsR 1.3.4
 
 - Fixing login issue due to backend changes made by Google (#103). Thanks to @MrLoh for initial implementation and suggestions.

--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -49,7 +49,7 @@ gconnect <- function(usr = NULL, psw = NULL, verbose = FALSE) {
     
     if (Sys.getenv("GOOGLE_USER") != "") usr <- Sys.getenv("GOOGLE_USER")
     
-    if (getOption("google.user") != "") usr <- getOption("google.user")
+    if (getOption("google.user", "") != "") usr <- getOption("google.user")
     
     if (is.null(usr)) stop("No Google Username / account supplied.", 
                            call. = FALSE)
@@ -59,7 +59,7 @@ gconnect <- function(usr = NULL, psw = NULL, verbose = FALSE) {
     
     if (Sys.getenv("GOOGLE_PASSWORD") != "") psw <- Sys.getenv("GOOGLE_PASSWORD")
     
-    if (getOption("google.password") != "") psw <- getOption("google.password")
+    if (getOption("google.password", "") != "") psw <- getOption("google.password")
     
     if (is.null(psw)) stop("No Google password supplied.", call. = FALSE)
   }


### PR DESCRIPTION
simpler and shorter than #122