### PR TITLE
Correctly parsing blocks that use the comma thousand separator (closes #133)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Added missing all DMAs within the US (#146).
 
+- Correctly parsing blocks that use the comma `,` thousand separator (#133).
+
 # gtrendsR 1.3.5
 
 - Added some missing country codes (#94). `data("countries")`.

--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -600,7 +600,7 @@ as.zoo.gtrends <- function(x, ...) {
     blocks <- lapply(start:length(vec), function(i) {
       
       dat <- vec[i]
-      dat <- gsub("(+\\d+)(,)", "\\1 ", dat) #replace thousand comma by a space
+      dat <- gsub("(+\\d+)(,)", "\\1", dat) #replace thousand comma by a space
       
       read.csv(textConnection(strsplit(dat, "\\\n")[[1]]),
                skip = 1,

--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -592,17 +592,20 @@ as.zoo.gtrends <- function(x, ...) {
   # Data likely returned monthly, so no geographical information.
   blocks <- NULL
   
-  if(length(vec) >= 3) {
+  if (length(vec) >= 3) {
     
     ## block 3+: geographical info
     start <- 3 # Always start at index 3
     
-    blocks <- lapply(start:length(vec), function(i)
-      read.csv(
-        textConnection(strsplit(vec[i], "\\\n")[[1]]),
-        skip = 1,
-        stringsAsFactors = FALSE
-      ))
+    blocks <- lapply(start:length(vec), function(i) {
+      
+      dat <- vec[i]
+      dat <- gsub("(+\\d+)(,)", "\\1 ", dat) #replace thousand comma by a space
+      
+      read.csv(textConnection(strsplit(dat, "\\\n")[[1]]),
+               skip = 1,
+               stringsAsFactors = FALSE)
+    })
     
     
     blocks <- Map(assign, 


### PR DESCRIPTION
Now correctly parse thousand comma separator.

This:

```r
> trends$Rising.searches.for.google
            facebook Breakout
1      google chrome Breakout
2    google tradutor Breakout
3               maps Breakout
4        maps google Breakout
5            youtube Breakout
6   translate google       +3
7               800%         
8          translate       +3
9               750%         
10      google earth       +3
11              600%         
12 traduction google       +1
13              350%   
```

becomes:

```r
> trends$Rising.searches.for.google
          facebook Breakout
1    google chrome Breakout
2     google earth Breakout
3  google tradutor Breakout
4          youtube Breakout
5             maps   +4800%
6      google play   +4550%
7      google maps   +3500%
8        translate   +3300%
9 google translate   +2950%
```