### PR TITLE
gtrends now considers gprop (news, youtube, etc)

### DIFF
--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -28,7 +28,7 @@
 #' @importFrom stats na.omit reshape
 #' @importFrom utils URLencode read.csv
 #'   
-#' @return An object of class \sQuote{gtrends} (basically a dataframe).
+#' @return An object of class \sQuote{gtrends} (basically a list of data frames).
 #'   
 #' @examples
 #' 
@@ -58,12 +58,17 @@
 #' 
 #' head(gtrends(c("NHL", "NFL"), time = "2010-01-01 2010-04-03")) 
 #' 
+#' ## Search from various Google's services
+#' 
+#' head(gtrends(c("NHL", "NFL"), gprop = "news")$interest_over_time)
+#' head(gtrends(c("NHL", "NFL"), gprop = "youtube")$interest_over_time)
+#' 
 #' @export
 gtrends <- function(
   keyword, 
   geo = "", 
   time = "today+5-y", 
-  gprop = c("", "news", "images", "froogle", "youtube"), 
+  gprop = c("web", "news", "images", "froogle", "youtube"), 
   category = 0) {
   
   stopifnot(
@@ -105,6 +110,7 @@ gtrends <- function(
   # geo <- "US"
   
   gprop <- match.arg(gprop, several.ok = FALSE)
+  gprop <- ifelse(gprop == "web", "", gprop)
   
   # ****************************************************************************
   # Request a token from Google
@@ -112,7 +118,7 @@ gtrends <- function(
   
   comparison_item <- data.frame(keyword, geo, time, stringsAsFactors = FALSE)
   
-  widget <- get_widget(comparison_item, category)
+  widget <- get_widget(comparison_item, category, gprop)
   
   # ****************************************************************************
   # Now that we have tokens, we can process the queries

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -211,10 +211,11 @@ create_geo_payload <- function(i, widget) {
   df$geo <- widget$geo[i]
   
   df$geo <- ifelse(df$geo == "", "world", df$geo)
+  df$gprop <- ifelse(widget$request$requestOptions$property[i] == "", "web", widget$request$requestOptions$property[i])
   df$id <- NULL
   rownames(df) <- NULL
   
-  names(df) <- c("location", "hits", "keyword", "geo")
+  names(df) <- c("location", "hits", "keyword", "geo", "gprop")
   
   return(df)
 }

--- a/man/gtrends.Rd
+++ b/man/gtrends.Rd
@@ -4,7 +4,7 @@
 \alias{gtrends}
 \title{Google Trends Query}
 \usage{
-gtrends(keyword, geo = "", time = "today+5-y", gprop = c("", "news",
+gtrends(keyword, geo = "", time = "today+5-y", gprop = c("web", "news",
   "images", "froogle", "youtube"), category = 0)
 }
 \arguments{
@@ -26,7 +26,7 @@ search), \dQuote{news}, \dQuote{images}, \dQuote{froogle} and
 \item{category}{A character denoting the category, defaults to \dQuote{0}.}
 }
 \value{
-An object of class \sQuote{gtrends} (basically a dataframe).
+An object of class \sQuote{gtrends} (basically a list of data frames).
 }
 \description{
 The \code{gtrends} default method performs a Google Trends query for the 
@@ -66,5 +66,10 @@ head(gtrends(c("NHL", "NFL"), time = "all")) # since 2004
 ## Custom date format
 
 head(gtrends(c("NHL", "NFL"), time = "2010-01-01 2010-04-03")) 
+
+## Search from various Google's services
+
+head(gtrends(c("NHL", "NFL"), gprop = "news")$interest_over_time)
+head(gtrends(c("NHL", "NFL"), gprop = "youtube")$interest_over_time)
 
 }


### PR DESCRIPTION
``` r

library(gtrendsR)

## Search from various Google's services

head(gtrends(c("NHL", "NFL"), gprop = "news")$interest_over_time)
#>         date hits keyword   geo gprop
#> 1 2012-02-26   11     NHL world  news
#> 2 2012-03-04    5     NHL world  news
#> 3 2012-03-11    5     NHL world  news
#> 4 2012-03-18    5     NHL world  news
#> 5 2012-03-25    6     NHL world  news
#> 6 2012-04-01    7     NHL world  news
head(gtrends(c("NHL", "NFL"), gprop = "youtube")$interest_over_time)
#>         date hits keyword   geo   gprop
#> 1 2012-02-26   27     NHL world youtube
#> 2 2012-03-04   25     NHL world youtube
#> 3 2012-03-11   23     NHL world youtube
#> 4 2012-03-18   25     NHL world youtube
#> 5 2012-03-25   25     NHL world youtube
#> 6 2012-04-01   28     NHL world youtube
```