### PR TITLE
extract related topics and related queries (closes #174)

### DIFF
--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -12,50 +12,46 @@
 #'   default to \dQuote{all} for global queries. Multiple regions are possible 
 #'   using \code{gtrends("NHL", c("CA", "US"))}.
 #'   
-#' @param time A string specifying the time span of the query. Possible values are:
-#' 
-#' \describe{
-#'   \item{"now 1-H"}{Last hour}
-#'   \item{"now 4-H"}{Last four hours}
-#'   \item{"now 1-d"}{Last day}
-#'   \item{"now 7-d"}{Last seven days}
-#'   \item{"today 1-m"}{Past 30 days}
-#'   \item{"today 3-m"}{Past 90 days}
-#'   \item{"today 12-m"}{Past 12 months}
-#'   \item{"today+5-y"}{Last five years (default)}
-#'   \item{"all"}{Since the beginning of Google Trends (2004)}
-#'   \item{"Y-m-d Y-m-d"}{Time span between two dates (ex.: "2010-01-01 2010-04-03")}
-#' }
+#' @param time A string specifying the time span of the query. Possible values
+#'   are:
+#'   
+#'   \describe{ \item{"now 1-H"}{Last hour} \item{"now 4-H"}{Last four hours} 
+#'   \item{"now 1-d"}{Last day} \item{"now 7-d"}{Last seven days} \item{"today
+#'   1-m"}{Past 30 days} \item{"today 3-m"}{Past 90 days} \item{"today
+#'   12-m"}{Past 12 months} \item{"today+5-y"}{Last five years (default)} 
+#'   \item{"all"}{Since the beginning of Google Trends (2004)} \item{"Y-m-d
+#'   Y-m-d"}{Time span between two dates (ex.: "2010-01-01 2010-04-03")} }
 #'   
 #' @param category A character denoting the category, defaults to \dQuote{0}.
 #'   
 #' @param gprop A character string defining the Google product for which the 
 #'   trend query if preformed. Valid options are:
 #'   
-#'   \itemize{
-#'   \item "web" (default)
-#'   \item "news"
-#'   \item "images"
-#'   \item "froogle"
-#'   \item "youtube"
-#' }
+#'   \itemize{ \item "web" (default) \item "news" \item "images" \item "froogle"
+#'   \item "youtube" }
 #'   
 #' @section Categories: The package includes a complete list of categories that 
 #'   can be used to narrow requests. These can be accessed using 
 #'   \code{data("categories")}.
 #'   
+#' @section Related topics: Note that *related topics* are not retrieved when
+#'   more than one keyword is provided due to Google restriction.
+#'   
 #' @importFrom stats na.omit reshape
 #' @importFrom utils URLencode read.csv
 #'   
-#' @return An object of class \sQuote{gtrends} (basically a list of data frames).
+#' @return An object of class \sQuote{gtrends} (basically a list of data
+#'   frames).
 #'   
 #' @examples
 #' 
-#' head(gtrends("NHL"))
+#' head(gtrends("NHL")$interest_over_time)
+#' head(gtrends("NHL")$related_topics)
+#' head(gtrends("NHL")$related_queries)
 #' 
-#' head(gtrends(c("NHL", "NFL")))
+#' head(gtrends(c("NHL", "NFL"))$interest_over_time)
 #' 
-#' head(gtrends(c("NHL", "NFL"), geo = c("CA", "US")))
+#' head(gtrends(c("NHL", "NFL"), geo = c("CA", "US"))$interest_over_time)
 #' 
 #' ## Sport category (20)
 #' data(categories)
@@ -143,10 +139,17 @@ gtrends <- function(
   # Now that we have tokens, we can process the queries
   # ****************************************************************************
   
-  df1 <- interest_over_time(widget, comparison_item)
-  df2 <- interest_by_region(widget, comparison_item)
-  
-  res <- list(interest_over_time = df1, interest_by_region = df2)
+  interest_over_time <- interest_over_time(widget, comparison_item)
+  interest_by_region <- interest_by_region(widget, comparison_item)
+  related_topics <- related_topics(widget, comparison_item)
+  related_queries <- related_queries(widget, comparison_item)
+    
+  res <- list(
+    interest_over_time = interest_over_time, 
+    interest_by_region = interest_by_region, 
+    related_topics = related_topics, 
+    related_queries = related_queries
+  )
   
   class(res) <- c("gtrends", "list")
  

--- a/R/related_queries.R
+++ b/R/related_queries.R
@@ -1,0 +1,78 @@
+related_queries <- function(widget, comparison_item) {
+  
+  i <- which(grepl("Related queries", widget$title) == TRUE)
+  
+  res <- lapply(i, create_related_queries_payload, widget = widget)
+  res <- do.call(rbind, res)
+  
+  return(res)
+}
+
+
+create_related_queries_payload <- function(i, widget) {
+  
+  payload2 <- list()
+  payload2$restriction$geo <-  as.list(widget$request$restriction$geo[i, , drop = FALSE])
+  payload2$restriction$time <- widget$request$restriction$time[[i]]
+  payload2$restriction$complexKeywordsRestriction$keyword <- widget$request$restriction$complexKeywordsRestriction$keyword[[i]]
+  payload2$keywordType <- widget$request$keywordType[[i]]
+  payload2$metric <- widget$request$metric[[i]]
+  payload2$trendinessSettings$compareTime <- widget$request$trendinessSettings$compareTime[[i]]
+  payload2$requestOptions$property <- widget$request$requestOptions$property[[i]]
+  payload2$requestOptions$backend <- widget$request$requestOptions$backend[[i]]
+  payload2$requestOptions$category <- widget$request$requestOptions$category[[i]]
+  payload2$language <- widget$request$language[[i]]
+  
+  url <- paste0(
+    "https://www.google.com/trends/api/widgetdata/relatedsearches/csv?req=",
+    jsonlite::toJSON(payload2, auto_unbox = T),
+    "&token=", widget$token[i],
+    "&tz=300&hl=en-US"
+  )
+  
+
+  res <- curl::curl_fetch_memory(URLencode(url))
+  
+  stopifnot(res$status_code == 200)
+  
+  res <- readLines(textConnection(rawToChar(res$content)))
+  
+  i <- which(grepl("$^", res))[1:2]
+  start <- i[1]
+  end <- i[2]
+  
+  top <- read.csv(textConnection(res[(start + 1):(end - 1)]))
+  top$subject <- rownames(top) 
+  rownames(top) <- NULL
+  top <- top[, c(2, 1)]
+  names(top) <- c("subject", "top")
+  
+  top <- reshape(
+    top,
+    varying = "top",
+    v.names = "value",
+    direction = "long",
+    timevar = "related_queries",
+    times = "top"
+  )
+  
+  rising <- read.csv(textConnection(res[(end + 1):length(res)]))
+  rising$subject <- rownames(rising) 
+  rownames(rising) <- NULL
+  rising <- rising[, c(2, 1)]
+  names(rising) <- c("subject", "rising")
+  
+  rising <- reshape(
+    rising,
+    varying = "rising",
+    v.names = "value",
+    direction = "long",
+    timevar = "related_queries",
+    times = "rising"
+  )
+  
+  res <- rbind(top, rising)
+  res$id <- NULL
+  
+  return(res)
+}

--- a/R/related_topics.R
+++ b/R/related_topics.R
@@ -1,0 +1,80 @@
+related_topics <- function(widget, comparison_item) {
+  
+  i <- which(grepl("Related topics", widget$title) == TRUE)
+  
+  ## Interest by region need to be retreived individually
+  
+  res <- lapply(i, create_related_topics_payload, widget = widget)
+  res <- do.call(rbind, res)
+  
+  
+  return(res)
+}
+
+
+create_related_topics_payload <- function(i, widget) {
+  
+  payload2 <- list()
+  payload2$restriction$geo <-  as.list(widget$request$geo[i, , drop = FALSE])
+  payload2$restriction$time <- widget$request$restriction$time[[i]]
+  payload2$restriction$complexKeywordsRestriction$keyword <- widget$request$restriction$complexKeywordsRestriction$keyword[[i]]
+  payload2$keywordType <- widget$request$keywordType[[i]]
+  payload2$metric <- widget$request$metric[[i]]
+  payload2$trendinessSettings$compareTime <- widget$request$trendinessSettings$compareTime[[i]]
+  payload2$requestOptions$property <- widget$request$requestOptions$property[[i]]
+  payload2$requestOptions$backend <- widget$request$requestOptions$backend[[i]]
+  payload2$requestOptions$category <- widget$request$requestOptions$category[[i]]
+  payload2$language <- widget$request$language[[i]]
+  
+  url <- paste0(
+    "https://www.google.com/trends/api/widgetdata/relatedsearches/csv?req=",
+    jsonlite::toJSON(payload2, auto_unbox = T),
+    "&token=", widget$token[i],
+    "&tz=300&hl=en-US"
+  )
+  
+  res <- curl::curl_fetch_memory(URLencode(url))
+  
+  stopifnot(res$status_code == 200)
+  
+  res <- readLines(textConnection(rawToChar(res$content)))
+  
+  i <- which(grepl("$^", res))[1:2]
+  start <- i[1]
+  end <- i[2]
+  
+  top <- read.csv(textConnection(res[(start + 1):(end - 1)]))
+  top$subject <- rownames(top) 
+  rownames(top) <- NULL
+  top <- top[, c(2, 1)]
+  names(top) <- c("subject", "top")
+  
+  top <- reshape(
+    top,
+    varying = "top",
+    v.names = "value",
+    direction = "long",
+    timevar = "related_topics",
+    times = "top"
+  )
+  
+  rising <- read.csv(textConnection(res[(end + 1):length(res)]))
+  rising$subject <- rownames(rising) 
+  rownames(rising) <- NULL
+  rising <- rising[, c(2, 1)]
+  names(rising) <- c("subject", "rising")
+  
+  rising <- reshape(
+    rising,
+    varying = "rising",
+    v.names = "value",
+    direction = "long",
+    timevar = "related_topics",
+    times = "rising"
+  )
+  
+  res <- rbind(top, rising)
+  res$id <- NULL
+  
+  return(res)
+}

--- a/man/gtrends.Rd
+++ b/man/gtrends.Rd
@@ -16,36 +16,27 @@ keywords. Multiple keywords are possible using \code{gtrends(c("NHL",
 default to \dQuote{all} for global queries. Multiple regions are possible 
 using \code{gtrends("NHL", c("CA", "US"))}.}
 
-\item{time}{A string specifying the time span of the query. Possible values are:
+\item{time}{A string specifying the time span of the query. Possible values
+are:
 
-\describe{
-  \item{"now 1-H"}{Last hour}
-  \item{"now 4-H"}{Last four hours}
-  \item{"now 1-d"}{Last day}
-  \item{"now 7-d"}{Last seven days}
-  \item{"today 1-m"}{Past 30 days}
-  \item{"today 3-m"}{Past 90 days}
-  \item{"today 12-m"}{Past 12 months}
-  \item{"today+5-y"}{Last five years (default)}
-  \item{"all"}{Since the beginning of Google Trends (2004)}
-  \item{"Y-m-d Y-m-d"}{Time span between two dates (ex.: "2010-01-01 2010-04-03")}
-}}
+\describe{ \item{"now 1-H"}{Last hour} \item{"now 4-H"}{Last four hours} 
+\item{"now 1-d"}{Last day} \item{"now 7-d"}{Last seven days} \item{"today
+1-m"}{Past 30 days} \item{"today 3-m"}{Past 90 days} \item{"today
+12-m"}{Past 12 months} \item{"today+5-y"}{Last five years (default)} 
+\item{"all"}{Since the beginning of Google Trends (2004)} \item{"Y-m-d
+Y-m-d"}{Time span between two dates (ex.: "2010-01-01 2010-04-03")} }}
 
 \item{gprop}{A character string defining the Google product for which the 
-  trend query if preformed. Valid options are:
-  
-  \itemize{
-  \item "web" (default)
-  \item "news"
-  \item "images"
-  \item "froogle"
-  \item "youtube"
-}}
+trend query if preformed. Valid options are:
+
+\itemize{ \item "web" (default) \item "news" \item "images" \item "froogle"
+\item "youtube" }}
 
 \item{category}{A character denoting the category, defaults to \dQuote{0}.}
 }
 \value{
-An object of class \sQuote{gtrends} (basically a list of data frames).
+An object of class \sQuote{gtrends} (basically a list of data
+  frames).
 }
 \description{
 The \code{gtrends} default method performs a Google Trends query for the 
@@ -58,13 +49,20 @@ geolocation and category can also be supplied.
   \code{data("categories")}.
 }
 
+\section{Related topics}{
+ Note that *related topics* are not retrieved when
+  more than one keyword is provided due to Google restriction.
+}
+
 \examples{
 
-head(gtrends("NHL"))
+head(gtrends("NHL")$interest_over_time)
+head(gtrends("NHL")$related_topics)
+head(gtrends("NHL")$related_queries)
 
-head(gtrends(c("NHL", "NFL")))
+head(gtrends(c("NHL", "NFL"))$interest_over_time)
 
-head(gtrends(c("NHL", "NFL"), geo = c("CA", "US")))
+head(gtrends(c("NHL", "NFL"), geo = c("CA", "US"))$interest_over_time)
 
 ## Sport category (20)
 data(categories)


### PR DESCRIPTION
``` r

library(gtrendsR)

head(gtrends("NHL")$interest_over_time)
#>         date hits keyword   geo gprop
#> 1 2012-03-11   45     NHL world   web
#> 2 2012-03-18   47     NHL world   web
#> 3 2012-03-25   50     NHL world   web
#> 4 2012-04-01   58     NHL world   web
#> 5 2012-04-08   83     NHL world   web
#> 6 2012-04-15   89     NHL world   web
head(gtrends("NHL")$related_topics)
#>                           subject related_topics value
#> 1          National Hockey League            top   100
#> 2 National Basketball Association            top     5
#> 3            Stanley Cup Playoffs            top     5
#> 4                      Ice hockey            top     5
#> 5           Major League Baseball            top     0
#> 6                             NFL            top     0
head(gtrends("NHL")$related_queries)
#>         subject related_queries value
#> 1    nhl scores             top   100
#> 2 nhl standings             top    90
#> 3           nba             top    75
#> 4        hockey             top    50
#> 5    nhl hockey             top    50
#> 6  nhl playoffs             top    45
```