### PR TITLE
can query categories without keywords (closes #173 #179)

### DIFF
--- a/R/related_queries.R
+++ b/R/related_queries.R
@@ -1,6 +1,6 @@
 related_queries <- function(widget, comparison_item) {
   
-  i <- which(grepl("Related queries", widget$title) == TRUE)
+  i <- which(grepl("queries", widget$title) == TRUE)
   
   res <- lapply(i, create_related_queries_payload, widget = widget)
   res <- do.call(rbind, res)
@@ -43,11 +43,14 @@ create_related_queries_payload <- function(i, widget) {
     return(NULL)
   }
   
-  i <- which(grepl("$^", res))[1:2]
-  start <- i[1]
-  end <- i[2]
+  start_top <- which(grepl("TOP", res))
+  start_rising <- which(grepl("RISING", res))
   
-  top <- read.csv(textConnection(res[(start + 1):(end - 1)]))
+  if (length(start_top) == 0 | length(start_rising) == 0) {
+    return(NULL) ## No data returned
+  }
+  
+  top <- read.csv(textConnection(res[start_top:(start_rising - 2)]), row.names = NULL)
   top$subject <- rownames(top) 
   rownames(top) <- NULL
   top <- top[, c(2, 1)]
@@ -62,7 +65,7 @@ create_related_queries_payload <- function(i, widget) {
     times = "top"
   )
   
-  rising <- read.csv(textConnection(res[(end + 1):length(res)]))
+  rising <- read.csv(textConnection(res[start_rising:length(res)]), row.names = NULL)
   rising$subject <- rownames(rising) 
   rownames(rising) <- NULL
   rising <- rising[, c(2, 1)]
@@ -81,6 +84,7 @@ create_related_queries_payload <- function(i, widget) {
   res$id <- NULL
   res$geo <-  unlist(payload2$restriction$geo, use.names = FALSE)
   res$keyword <- payload2$restriction$complexKeywordsRestriction$keyword$value
+  res$category <- payload2$requestOptions$category
   
   return(res)
 }

--- a/R/related_topics.R
+++ b/R/related_topics.R
@@ -1,6 +1,6 @@
 related_topics <- function(widget, comparison_item) {
   
-  i <- which(grepl("Related topics", widget$title) == TRUE)
+  i <- which(grepl("topics", widget$title) == TRUE)
   
   res <- lapply(i, create_related_topics_payload, widget = widget)
   res <- do.call(rbind, res)
@@ -36,11 +36,14 @@ create_related_topics_payload <- function(i, widget) {
   
   res <- readLines(textConnection(rawToChar(res$content)))
   
-  i <- which(grepl("$^", res))[1:2]
-  start <- i[1]
-  end <- i[2]
+  start_top <- which(grepl("TOP", res))
+  start_rising <- which(grepl("RISING", res))
   
-  top <- read.csv(textConnection(res[(start + 1):(end - 1)]), row.names = NULL)
+  if (length(start_top) == 0 | length(start_rising) == 0) {
+    return(NULL) ## No data returned
+  }
+  
+  top <- read.csv(textConnection(res[start_top:(start_rising - 2)]), row.names = NULL)
   top$subject <- rownames(top) 
   rownames(top) <- NULL
   top <- top[, c(2, 1)]
@@ -55,7 +58,7 @@ create_related_topics_payload <- function(i, widget) {
     times = "top"
   )
   
-  rising <- read.csv(textConnection(res[(end + 1):length(res)]), row.names = NULL)
+  rising <- read.csv(textConnection(res[start_rising:length(res)]), row.names = NULL)
   rising$subject <- rownames(rising) 
   rownames(rising) <- NULL
   rising <- rising[, c(2, 1)]
@@ -74,6 +77,7 @@ create_related_topics_payload <- function(i, widget) {
   res$id <- NULL
   res$geo <-  unlist(payload2$restriction$geo, use.names = FALSE)
   res$keyword <- payload2$restriction$complexKeywordsRestriction$keyword$value
+  res$category <- payload2$requestOptions$category
   
   return(res)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -109,6 +109,10 @@ interest_over_time <- function(widget, comparison_item) {
                  skip = 1,
                  stringsAsFactors = FALSE)
   
+  if (nrow(df) < 1) {
+    return(NULL) ## No data
+  }
+  
   n <- nrow(df) # used to reshape the data
   
   df <- reshape(
@@ -128,6 +132,7 @@ interest_over_time <- function(widget, comparison_item) {
   
   df$geo <- ifelse(df$geo == "", "world", df$geo)
   df$gprop <- ifelse(widget$request$requestOptions$property[1] == "", "web", widget$request$requestOptions$property[1])
+  df$category <- widget$request$requestOptions$category[1]
   names(df)[1] <- "date"
   df$id <- NULL
   
@@ -228,6 +233,7 @@ create_geo_payload <- function(i, widget, resolution) {
   
   df$geo <- ifelse(df$geo == "", "world", df$geo)
   df$gprop <- ifelse(widget$request$requestOptions$property[i] == "", "web", widget$request$requestOptions$property[i])
+  
   df$id <- NULL
   rownames(df) <- NULL
   


### PR DESCRIPTION
``` r

library(gtrendsR)

res <- gtrends("", category = "1267", geo = "NO", time = "all")

lapply(res, head)
#> $interest_over_time
#>         date hits keyword geo gprop category
#> 1 2004-01-01   88          NO   web     1267
#> 2 2004-02-01   87          NO   web     1267
#> 3 2004-03-01   60          NO   web     1267
#> 4 2004-04-01   65          NO   web     1267
#> 5 2004-05-01   65          NO   web     1267
#> 6 2004-06-01   83          NO   web     1267
#> 
#> $interest_by_region
#> NULL
#> 
#> $interest_by_dma
#> NULL
#> 
#> $interest_by_city
#> NULL
#> 
#> $related_topics
#>   subject related_topics         value geo category
#> 1     100            top           Car  NO     1267
#> 2      80            top Specification  NO     1267
#> 3      45            top    Combustion  NO     1267
#> 4      30            top         Value  NO     1267
#> 5      30            top    Horsepower  NO     1267
#> 6      25            top  BMW 1 Series  NO     1267
#> 
#> $related_queries
#>   subject related_queries        value geo category
#> 1     100             top        specs  NO     1267
#> 2      70             top konkurrenten  NO     1267
#> 3      30             top       toyota  NO     1267
#> 4      30             top       reflex  NO     1267
#> 5      25             top     modeller  NO     1267
#> 6      20             top         spec  NO     1267
```