### PR TITLE
Language locale resolved

### DIFF
--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -147,7 +147,7 @@ gtrends <- function(
   
   comparison_item <- data.frame(keyword, geo, time, stringsAsFactors = FALSE)
   
-  widget <- get_widget(comparison_item, category, gprop)
+  widget <- get_widget(comparison_item, category, gprop, hl)
   
   # ****************************************************************************
   # Now that we have tokens, we can process the queries

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -55,20 +55,22 @@ check_time <- function(time) {
 }
 
 
-get_widget <- function(comparison_item, category, gprop) {
+get_widget <- function(comparison_item, category, gprop, hl) {
 
   token_payload <- list()
   token_payload$comparisonItem <- comparison_item
   token_payload$category <- category
   token_payload$property <- gprop
+  tz = 100
 
   url <- URLencode(paste0("https://www.google.com/trends/api/explore?property=&req=",
                           jsonlite::toJSON(token_payload, auto_unbox = TRUE),
-                          "&tz=300&hl=en-US")) ## Need better than this
+                          "&tz=300&hl=", hl)) ## Need better than this
 
   widget <- curl::curl_fetch_memory(url)
 
   stopifnot(widget$status_code == 200)
+
   
   ## Fix encoding issue for keywords like österreich"
   temp <- rawToChar(widget$content)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -61,11 +61,12 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   token_payload$comparisonItem <- comparison_item
   token_payload$category <- category
   token_payload$property <- gprop
-  tz = 100
 
   url <- URLencode(paste0("https://www.google.com/trends/api/explore?property=&req=",
                           jsonlite::toJSON(token_payload, auto_unbox = TRUE),
-                          "&tz=300&hl=", hl)) ## Need better than this
+                          "&tz=300&hl=", hl)) ## The tz part is unclear but different
+                                              ## valid values do not change the result:
+                                              ## clarification needed.
 
   widget <- curl::curl_fetch_memory(url)
 
@@ -95,10 +96,10 @@ interest_over_time <- function(widget, comparison_item) {
 
 
   url <- paste0(
-    "https://www.google.fr/trends/api/widgetdata/multiline/csv?req=",
+    "https://www.google.com/trends/api/widgetdata/multiline/csv?req=",
     jsonlite::toJSON(payload2, auto_unbox = T),
     "&token=", widget$token[1],
-    "&tz=360"
+    "&tz=300"
   )
 
   # ****************************************************************************


### PR DESCRIPTION
Hi, 

To avoid confusion, I re-created this PL after the main branch had the resolution to the non-ASCII characters. 

--- Language and coding ---
There are three issues here:
- The hl= parameter for gtrends() is verified in gtrends.R line 108
- it is now passed on correctly to the get_widget()
- it is passed on in the url request (this was missing, it was set constantly to en-US, even when the user sent a fr-FR) 
- the widget then passes on this information to other zzz function like get interest over time or region.

The hl (locale) parameter does have some effect on what is returned not only in terms of data, but also metadata. 

I can confirm that the new non-ASCII fix works with the search term, but there is still some problem in the metadata, for example, the names of subregions, if they have non-ASCII characters, are not always correct.  It is not clear to me, because the non-ASCII fix should apply on the whole content of the widget, including subregions. 

--- tz offest -- 
The zzz functions used this as a constant, once set to 300, once to 360. It is still unclear to me what is the meaning of this parameter, but I set it to 300 so that there is no mismatch in quarries. However, it may be overruled by hl, because for me it gave the same response with values 0, 100, 300, 360, and with non-valid values like -200 or 12000 it gave an error.

To be more precise, I seem to get a res returned with date and time in UTC whatever I enter as a tz parameter, i.e. tz=200, tz=300, tz=360.  If this is the case from other locales (I am in nl-NL, tried hu-HU) then this could be a documentation issue, because in this case we can be sure that wherever the user calls the function, he or she will get a UTC response, and in short-term, intra-day queries should  adjust the date parameter of the returned res object accordingly, i.e. to the time zone corresponding to the hl locale.  

--- google.com vs google.fr --- 

I realized that sometimes you are calling google.com and sometimes google.fr.   The localization may effect the problematic metadata returns, or just simply slow down things.  I set it to google.com, I believe that it will direct to google.fr when called with fr-FR, and google.com from the US.

I think it is clear now.  Together with the non-ASCII fix, it really improves usability. 
 