### PR TITLE
Can now search with keywords containing '&' (closes #267)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtrendsR 1.4.2 (unreleased)
 
+- Now able to search with "&" character (#267). `gtrends("A&W", geo = "CA")`
+
 - gtrendsR now depends on R >= 3.2.0 (#264)
 
 # gtrendsR 1.4.1

--- a/R/related_queries.R
+++ b/R/related_queries.R
@@ -22,14 +22,14 @@ create_related_queries_payload <- function(i, widget) {
   payload2$requestOptions$category <- widget$request$requestOptions$category[[i]]
   payload2$language <- widget$request$language[[i]]
 
-  url <- paste0(
+  url <- URLencode(paste0(
     "https://www.google.com/trends/api/widgetdata/relatedsearches/csv?req=",
     jsonlite::toJSON(payload2, auto_unbox = T),
     "&token=", widget$token[i],
     "&tz=300&hl=en-US"
-  )
+  ))
 
-
+  url <- encode_keyword(url)
   res <- curl::curl_fetch_memory(URLencode(url))
 
   stopifnot(res$status_code == 200)

--- a/R/related_topics.R
+++ b/R/related_topics.R
@@ -22,15 +22,16 @@ create_related_topics_payload <- function(i, widget, hl) {
   payload2$requestOptions$category <- widget$request$requestOptions$category[[i]]
   payload2$language <- widget$request$language[[i]]
 
-  url <- paste0(
+  url <- URLencode(paste0(
     "https://trends.google.com/trends/api/widgetdata/relatedsearches/csv?req=",
     # "https://www.google.com/trends/api/widgetdata/relatedsearches/csv?req=",
     jsonlite::toJSON(payload2, auto_unbox = T),
     "&token=", widget$token[i],
     "&tz=300&hl=", hl
-  )
+  ))
 
-  res <- curl::curl_fetch_memory(URLencode(url))
+  url <- encode_keyword(url)
+  res <- curl::curl_fetch_memory(url)
 
   stopifnot(res$status_code == 200)
 


### PR DESCRIPTION
``` r
  library(gtrendsR)

  plot(gtrends("Bath & body works", geo = "US"))
```

![](https://i.imgur.com/ILwKITs.png)

``` r

  plot(gtrends(keyword = "S&P500", geo = "US", time = "2004-01-01 2017-12-31"))
```

![](https://i.imgur.com/jEImerA.png)

Created on 2018-05-23 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).