### PR TITLE
Fixes cookie handling issue introduced on 2018-05-28

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,9 +5,9 @@ get_api_cookies <- function() {
   # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
   # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
   curl::handle_cookies(cookie_handler)
-  # cookie_handler <<- cookie_handler
+  cookie_handler <<- cookie_handler
   # assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR')) # not sure what I'm doing, hopefully this works?
-  assignInMyNamespace("cookie_handler", cookie_handler)
+  # assignInMyNamespace("cookie_handler", cookie_handler)
   return(NULL)
 }
 
@@ -89,8 +89,8 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   if(!exists("cookie_handler")){ get_api_cookies() }
   
   # widget <- curl::curl_fetch_memory(url, handle = as.environment('package:gtrendsR')$cookie_handler)
-  # widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
-  widget <- curl::curl_fetch_memory(url, handle = get("cookie_handler"))
+  widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
+  # widget <- curl::curl_fetch_memory(url, handle = get("cookie_handler"))
 
   stopifnot(widget$status_code == 200)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,7 +5,9 @@ get_api_cookies <- function() {
   # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
   # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
   curl::handle_cookies(cookie_handler)
-  assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR')) # not sure what I'm doing, hopefully this works?
+  # cookie_handler <<- cookie_handler
+  # assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR')) # not sure what I'm doing, hopefully this works?
+  assignInMyNamespace("cookie_handler", cookie_handler)
   return(NULL)
 }
 
@@ -83,9 +85,12 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   url <- encode_keyword(url)
   
   # if cookie_handler hasn't been set up, get the requisite cookies from Google's API
-  if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
+  # if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
+  if(!exists("cookie_handler")){ get_api_cookies() }
   
-  widget <- curl::curl_fetch_memory(url, handle = as.environment('package:gtrendsR')$cookie_handler)
+  # widget <- curl::curl_fetch_memory(url, handle = as.environment('package:gtrendsR')$cookie_handler)
+  # widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
+  widget <- curl::curl_fetch_memory(url, handle = get("cookie_handler"))
 
   stopifnot(widget$status_code == 200)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,16 +1,18 @@
-#.pkgenv <- new.env(parent=emptyenv())
+.pkgenv <- new.env(parent=emptyenv())
 
-cookie_handler <- curl::new_handle()
-cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
-curl::handle_cookies(cookie_handler)
+#cookie_handler <- curl::new_handle()
+#cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
+#curl::handle_cookies(cookie_handler)
 
 # function to create cookie_handler, which is necessary to run get_widget()
-#get_api_cookies <- function() {
-#  cookie_handler <- curl::new_handle()
-#  cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
+get_api_cookies <- function() {
+  cookie_handler <- curl::new_handle()
+  cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
   # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
   # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
-#  curl::handle_cookies(cookie_handler)
+  curl::handle_cookies(cookie_handler)
+  .pkgenv[["cookie_handler"]] <- cookie_handler
+  #assign("cookie_handler", cookie_handler, envir = .pkgenv)
   # cookie_handler <<- cookie_handler
   # assignInMyNamespace("cookie_handler", cookie_handler)
   #unlockBinding("cookie_handler", env = as.environment('package:gtrendsR'))
@@ -19,8 +21,8 @@ curl::handle_cookies(cookie_handler)
 #  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.) # i'm guessing this is bad practice but it works
   # assign("cookie_handler", cookie_handler, envir = asNamespace('gtrendsR'))
   #lockEnvironment(as.environment('package:gtrendsR'))
-#  return(NULL)
-#}
+  return(NULL)
+}
 
 check_time <- function(time) {
   stopifnot(is.character(time))
@@ -101,7 +103,8 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   # if(!exists("cookie_handler")){ get_api_cookies() }
   
   #widget <- curl::curl_fetch_memory(url, handle = gtrendsR:::.__NAMESPACE__.$cookie_handler) # I'm not sure you're supposed to do this but it works
-   widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
+  # widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
+  widget <- curl::curl_fetch_memory(url, handle = .pkgenv[["cookie_handler"]])
 
   stopifnot(widget$status_code == 200)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,14 @@
+# function to create cookie_handler, which is necessary to run get_widget()
+get_api_cookies <- function() {
+  cookie_handler <- curl::new_handle()
+  cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
+  # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
+  # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
+  curl::handle_cookies(cookie_handler)
+  assign("cookie_handler", cookie_handler, pos = -1) # not sure what I'm doing, hopefully this works?
+  return(NULL)
+}
+
 check_time <- function(time) {
   stopifnot(is.character(time))
 
@@ -71,7 +82,10 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   
   url <- encode_keyword(url)
   
-  widget <- curl::curl_fetch_memory(url)
+  # if cookie_handler hasn't been set up, get the requisite cookies from Google's API
+  if(!exists("cookie_handler", where = -1)){ get_api_cookies() }
+  
+  widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
 
   stopifnot(widget$status_code == 200)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,7 +5,7 @@ get_api_cookies <- function() {
   # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
   # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
   curl::handle_cookies(cookie_handler)
-  assign("cookie_handler", cookie_handler, pos = -1) # not sure what I'm doing, hopefully this works?
+  assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR')) # not sure what I'm doing, hopefully this works?
   return(NULL)
 }
 
@@ -83,9 +83,9 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   url <- encode_keyword(url)
   
   # if cookie_handler hasn't been set up, get the requisite cookies from Google's API
-  if(!exists("cookie_handler", where = -1)){ get_api_cookies() }
+  if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
   
-  widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
+  widget <- curl::curl_fetch_memory(url, handle = as.environment('package:gtrendsR')$cookie_handler)
 
   stopifnot(widget$status_code == 200)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,26 +1,17 @@
+# create environment in which to put cookie_handler
 .pkgenv <- new.env(parent=emptyenv())
-
-#cookie_handler <- curl::new_handle()
-#cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
-#curl::handle_cookies(cookie_handler)
 
 # function to create cookie_handler, which is necessary to run get_widget()
 get_api_cookies <- function() {
+  # create new handler
   cookie_handler <- curl::new_handle()
+  # fetch API cookies
   cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
   # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
   # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
   curl::handle_cookies(cookie_handler)
+  # assign handler to .pkgenv environment
   .pkgenv[["cookie_handler"]] <- cookie_handler
-  #assign("cookie_handler", cookie_handler, envir = .pkgenv)
-  # cookie_handler <<- cookie_handler
-  # assignInMyNamespace("cookie_handler", cookie_handler)
-  #unlockBinding("cookie_handler", env = as.environment('package:gtrendsR'))
-  # assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR'))
-#  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.) # i'm guessing this is bad practice but it works
-#  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.) # i'm guessing this is bad practice but it works
-  # assign("cookie_handler", cookie_handler, envir = asNamespace('gtrendsR'))
-  #lockEnvironment(as.environment('package:gtrendsR'))
   return(NULL)
 }
 
@@ -99,16 +90,10 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   
   # if cookie_handler hasn't been set up, get the requisite cookies from Google's API
   if(!exists("cookie_handler", envir = .pkgenv)){ get_api_cookies() }
-  #if(!exists("cookie_handler", envir = gtrendsR:::.__NAMESPACE__.)){ get_api_cookies() }
-  # if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
-  # if(!exists("cookie_handler")){ get_api_cookies() }
-  
-  #widget <- curl::curl_fetch_memory(url, handle = gtrendsR:::.__NAMESPACE__.$cookie_handler) # I'm not sure you're supposed to do this but it works
-  # widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
+  # get the tokens etc., using the URL and the cookie_handler
   widget <- curl::curl_fetch_memory(url, handle = .pkgenv[["cookie_handler"]])
 
   stopifnot(widget$status_code == 200)
-
 
   ## Fix encoding issue for keywords like österreich"
   temp <- rawToChar(widget$content)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -7,9 +7,10 @@ get_api_cookies <- function() {
   curl::handle_cookies(cookie_handler)
   # cookie_handler <<- cookie_handler
   # assignInMyNamespace("cookie_handler", cookie_handler)
-  unlockBinding("cookie_handler", env = as.environment('package:gtrendsR'))
-  assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR'))
-  lockEnvironment(as.environment('package:gtrendsR'))
+  #unlockBinding("cookie_handler", env = as.environment('package:gtrendsR'))
+  # assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR'))
+  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.)
+  #lockEnvironment(as.environment('package:gtrendsR'))
   return(NULL)
 }
 
@@ -87,10 +88,12 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   url <- encode_keyword(url)
   
   # if cookie_handler hasn't been set up, get the requisite cookies from Google's API
-  if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
+  if(!exists("cookie_handler", envir = gtrendsR:::.__NAMESPACE__.)){ get_api_cookies() }
+  # if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
   # if(!exists("cookie_handler")){ get_api_cookies() }
   
-  widget <- curl::curl_fetch_memory(url, handle = as.environment('package:gtrendsR')$cookie_handler)
+  widget <- curl::curl_fetch_memory(url, handle = gtrendsR:::cookie_handler)
+  # widget <- curl::curl_fetch_memory(url, handle = as.environment('package:gtrendsR')$cookie_handler)
   # widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
   # widget <- curl::curl_fetch_memory(url, handle = get("cookie_handler"))
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,9 +5,11 @@ get_api_cookies <- function() {
   # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
   # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
   curl::handle_cookies(cookie_handler)
-  cookie_handler <<- cookie_handler
-  # assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR')) # not sure what I'm doing, hopefully this works?
+  # cookie_handler <<- cookie_handler
   # assignInMyNamespace("cookie_handler", cookie_handler)
+  unlockBinding("cookie_handler", envir = as.environment('package:gtrendsR'))
+  assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR'))
+  lockEnvironment(as.environment('package:gtrendsR'))
   return(NULL)
 }
 
@@ -85,11 +87,11 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   url <- encode_keyword(url)
   
   # if cookie_handler hasn't been set up, get the requisite cookies from Google's API
-  # if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
-  if(!exists("cookie_handler")){ get_api_cookies() }
+  if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
+  # if(!exists("cookie_handler")){ get_api_cookies() }
   
-  # widget <- curl::curl_fetch_memory(url, handle = as.environment('package:gtrendsR')$cookie_handler)
-  widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
+  widget <- curl::curl_fetch_memory(url, handle = as.environment('package:gtrendsR')$cookie_handler)
+  # widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
   # widget <- curl::curl_fetch_memory(url, handle = get("cookie_handler"))
 
   stopifnot(widget$status_code == 200)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,7 +9,8 @@ get_api_cookies <- function() {
   # assignInMyNamespace("cookie_handler", cookie_handler)
   #unlockBinding("cookie_handler", env = as.environment('package:gtrendsR'))
   # assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR'))
-  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.)
+  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.) # i'm guessing this is bad practice but it works
+  # assign("cookie_handler", cookie_handler, envir = asNamespace('gtrendsR'))
   #lockEnvironment(as.environment('package:gtrendsR'))
   return(NULL)
 }
@@ -92,11 +93,8 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   # if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
   # if(!exists("cookie_handler")){ get_api_cookies() }
   
-  widget <- curl::curl_fetch_memory(url, handle = gtrendsR:::cookie_handler)
-  # widget <- curl::curl_fetch_memory(url, handle = as.environment('package:gtrendsR')$cookie_handler)
-  # widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
-  # widget <- curl::curl_fetch_memory(url, handle = get("cookie_handler"))
-
+  widget <- curl::curl_fetch_memory(url, handle = gtrendsR:::.__NAMESPACE__.$cookie_handler) # I'm not sure you're supposed to do this but it works
+  
   stopifnot(widget$status_code == 200)
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,11 +1,13 @@
+#.pkgenv <- new.env(parent=emptyenv())
+
 cookie_handler <- curl::new_handle()
-  curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
-  curl::handle_cookies(cookie_handler)
+cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
+curl::handle_cookies(cookie_handler)
 
 # function to create cookie_handler, which is necessary to run get_widget()
 #get_api_cookies <- function() {
-  #cookie_handler <- curl::new_handle()
- # cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
+#  cookie_handler <- curl::new_handle()
+#  cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
   # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
   # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
 #  curl::handle_cookies(cookie_handler)
@@ -13,6 +15,7 @@ cookie_handler <- curl::new_handle()
   # assignInMyNamespace("cookie_handler", cookie_handler)
   #unlockBinding("cookie_handler", env = as.environment('package:gtrendsR'))
   # assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR'))
+#  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.) # i'm guessing this is bad practice but it works
 #  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.) # i'm guessing this is bad practice but it works
   # assign("cookie_handler", cookie_handler, envir = asNamespace('gtrendsR'))
   #lockEnvironment(as.environment('package:gtrendsR'))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,19 +1,23 @@
+cookie_handler <- curl::new_handle()
+  curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
+  curl::handle_cookies(cookie_handler)
+
 # function to create cookie_handler, which is necessary to run get_widget()
-get_api_cookies <- function() {
-  cookie_handler <- curl::new_handle()
-  cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
+#get_api_cookies <- function() {
+  #cookie_handler <- curl::new_handle()
+ # cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
   # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
   # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
-  curl::handle_cookies(cookie_handler)
+#  curl::handle_cookies(cookie_handler)
   # cookie_handler <<- cookie_handler
   # assignInMyNamespace("cookie_handler", cookie_handler)
   #unlockBinding("cookie_handler", env = as.environment('package:gtrendsR'))
   # assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR'))
-  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.) # i'm guessing this is bad practice but it works
+#  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.) # i'm guessing this is bad practice but it works
   # assign("cookie_handler", cookie_handler, envir = asNamespace('gtrendsR'))
   #lockEnvironment(as.environment('package:gtrendsR'))
-  return(NULL)
-}
+#  return(NULL)
+#}
 
 check_time <- function(time) {
   stopifnot(is.character(time))
@@ -89,12 +93,13 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   url <- encode_keyword(url)
   
   # if cookie_handler hasn't been set up, get the requisite cookies from Google's API
-  if(!exists("cookie_handler", envir = gtrendsR:::.__NAMESPACE__.)){ get_api_cookies() }
+  #if(!exists("cookie_handler", envir = gtrendsR:::.__NAMESPACE__.)){ get_api_cookies() }
   # if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
   # if(!exists("cookie_handler")){ get_api_cookies() }
   
-  widget <- curl::curl_fetch_memory(url, handle = gtrendsR:::.__NAMESPACE__.$cookie_handler) # I'm not sure you're supposed to do this but it works
-  
+  #widget <- curl::curl_fetch_memory(url, handle = gtrendsR:::.__NAMESPACE__.$cookie_handler) # I'm not sure you're supposed to do this but it works
+   widget <- curl::curl_fetch_memory(url, handle = cookie_handler)
+
   stopifnot(widget$status_code == 200)
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -98,6 +98,7 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   url <- encode_keyword(url)
   
   # if cookie_handler hasn't been set up, get the requisite cookies from Google's API
+  if(!exists("cookie_handler", envir = .pkgenv)){ get_api_cookies() }
   #if(!exists("cookie_handler", envir = gtrendsR:::.__NAMESPACE__.)){ get_api_cookies() }
   # if(!exists("cookie_handler", envir = as.environment('package:gtrendsR'))){ get_api_cookies() }
   # if(!exists("cookie_handler")){ get_api_cookies() }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -7,7 +7,7 @@ get_api_cookies <- function() {
   curl::handle_cookies(cookie_handler)
   # cookie_handler <<- cookie_handler
   # assignInMyNamespace("cookie_handler", cookie_handler)
-  unlockBinding("cookie_handler", envir = as.environment('package:gtrendsR'))
+  unlockBinding("cookie_handler", env = as.environment('package:gtrendsR'))
   assign("cookie_handler", cookie_handler, envir = as.environment('package:gtrendsR'))
   lockEnvironment(as.environment('package:gtrendsR'))
   return(NULL)


### PR DESCRIPTION
I've never written an R package before, so I'm not sure this is best practice. But it creates the necessary cookie handler and fixes get_widget().

In particular, these are the questionable lines: 
```
  assign("cookie_handler", cookie_handler, envir = gtrendsR:::.__NAMESPACE__.) # i'm guessing this is bad practice but it works
  if(!exists("cookie_handler", envir = gtrendsR:::.__NAMESPACE__.)){ get_api_cookies() }
  widget <- curl::curl_fetch_memory(url, handle = gtrendsR:::.__NAMESPACE__.$cookie_handler) # I'm not sure you're supposed to do this but it works
```
I couldn't figure out a good way to create the handler that would be safe from the global environment. I can't create things in the namespace of the package because it is locked. I couldn't find anything online as to best practice for this sort of thing.