### PR TITLE
Changed default cookie URL; added it as a parameter for top-level function

### DIFF
--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -36,6 +36,9 @@
 #'
 #' @param low_search_volume Logical. Should include low search volume regions?
 #'
+#' @param cookie_url A string specifying the URL from which to obtain cookies.
+#'   Default should work in general; should only be changed by advanced users.
+#'
 #' @section Categories: The package includes a complete list of categories that
 #'   can be used to narrow requests. These can be accessed using
 #'   \code{data("categories")}.
@@ -105,7 +108,8 @@ gtrends <- function(
                     gprop = c("web", "news", "images", "froogle", "youtube"),
                     category = 0,
                     hl = "en-US",
-                    low_search_volume = FALSE) {
+                    low_search_volume = FALSE,
+                    cookie_url = "http://trends.google.com/Cookies/NID") {
   stopifnot(
     # One  vector should be a multiple of the other
     (length(keyword) %% length(geo) == 0) || (length(geo) %% length(keyword) == 0),
@@ -115,7 +119,9 @@ gtrends <- function(
     length(time) == 1,
     length(hl) == 1,
     is.character(hl),
-    hl %in% language_codes$code
+    hl %in% language_codes$code,
+    length(cookie_url) == 1,
+    is.character(cookie_url)
   )
 
 
@@ -160,7 +166,7 @@ gtrends <- function(
 
   comparison_item <- data.frame(keyword, geo, time, stringsAsFactors = FALSE)
 
-  widget <- get_widget(comparison_item, category, gprop, hl)
+  widget <- get_widget(comparison_item, category, gprop, hl, cookie_url)
 
   # ****************************************************************************
   # Now that we have tokens, we can process the queries

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,18 +1,13 @@
 # create environment in which to put cookie_handler
 .pkgenv <- new.env(parent=emptyenv())
 
-# specify the cookie URL; can be overwritten by user by changing gtrendsR:::.pkgenv$cookie_url
-# e.g., alternative url is "http://apis.google.com/Cookies/OTZ"
-.pkgenv[["cookie_url"]] <- "http://trends.google.com/Cookies/NID"
-
+# alternative url is "http://apis.google.com/Cookies/OTZ"
 # function to create cookie_handler, which is necessary to run get_widget()
-get_api_cookies <- function() {
+get_api_cookies <- function(cookie_url) {
   # create new handler
   cookie_handler <- curl::new_handle()
   # fetch API cookies
-  cookie_req <- curl::curl_fetch_memory(.pkgenv[["cookie_url"]], handle = cookie_handler)
-  # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
-  # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
+  cookie_req <- curl::curl_fetch_memory(cookie_url, handle = cookie_handler)
   curl::handle_cookies(cookie_handler)
   # assign handler to .pkgenv environment
   .pkgenv[["cookie_handler"]] <- cookie_handler
@@ -74,7 +69,7 @@ check_time <- function(time) {
 }
 
 
-get_widget <- function(comparison_item, category, gprop, hl) {
+get_widget <- function(comparison_item, category, gprop, hl, cookie_url) {
   token_payload <- list()
   token_payload$comparisonItem <- comparison_item
   token_payload$category <- category
@@ -93,7 +88,7 @@ get_widget <- function(comparison_item, category, gprop, hl) {
   url <- encode_keyword(url)
   
   # if cookie_handler hasn't been set up, get the requisite cookies from Google's API
-  if(!exists("cookie_handler", envir = .pkgenv)){ get_api_cookies() }
+  if(!exists("cookie_handler", envir = .pkgenv)){ get_api_cookies(cookie_url) }
   # get the tokens etc., using the URL and the cookie_handler
   widget <- curl::curl_fetch_memory(url, handle = .pkgenv[["cookie_handler"]])
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,12 +1,16 @@
 # create environment in which to put cookie_handler
 .pkgenv <- new.env(parent=emptyenv())
 
+# specify the cookie URL; can be overwritten by user by changing gtrendsR:::.pkgenv$cookie_url
+# e.g., alternative url is "http://apis.google.com/Cookies/OTZ"
+.pkgenv[["cookie_url"]] <- "http://trends.google.com/Cookies/NID"
+
 # function to create cookie_handler, which is necessary to run get_widget()
 get_api_cookies <- function() {
   # create new handler
   cookie_handler <- curl::new_handle()
   # fetch API cookies
-  cookie_req <- curl::curl_fetch_memory("http://apis.google.com/Cookies/OTZ", handle = cookie_handler)
+  cookie_req <- curl::curl_fetch_memory(.pkgenv[["cookie_url"]], handle = cookie_handler)
   # according to @RKushnir, one could do this instead (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309):
   # cookie_req <- curl_fetch_memory("http://trends.google.com/Cookies/NID", handle = cookie_handler)
   curl::handle_cookies(cookie_handler)

--- a/man/gtrends.Rd
+++ b/man/gtrends.Rd
@@ -6,7 +6,7 @@
 \usage{
 gtrends(keyword = NA, geo = "", time = "today+5-y", gprop = c("web",
   "news", "images", "froogle", "youtube"), category = 0, hl = "en-US",
-  low_search_volume = FALSE)
+  low_search_volume = FALSE, cookie_url = "http://trends.google.com/Cookies/NID")
 }
 \arguments{
 \item{keyword}{A character vector with the actual Google Trends query
@@ -40,6 +40,9 @@ using \code{gtrends("NHL", c("CA", "US"))}.}
 the data returned by related topics.}
 
 \item{low_search_volume}{Logical. Should include low search volume regions?}
+  
+\item{cookie_url}{A string specifying the URL from which to obtain cookies. 
+Default should work in general; should only be changed by advanced users.}
 }
 \value{
 An object of class \sQuote{gtrends} (basically a list of data


### PR DESCRIPTION
It looks like the NID cookie from trends.google.com, as used in https://github.com/GeneralMills/pytrends and recommended by @RKushnir, is preferable to the more general api.google.com cookie I had used. As noted by @bbakk14, the former works behind a firewall that blocks social media, whereas the latter does not (apparently because it includes Google+?).

Therefore, I changed the default. And, in case users want to use other URLs, I added it as a parameter (with the NID URL being the default) to the top-level function, gtrends() (and updated the man page). In the future, if the URL changes, we can simply change it in the default set by the gtrends() function.