### PR TITLE
Coherce hits column to numeric

### DIFF
--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -216,7 +216,11 @@ gtrends <- function(
 #' }
 plot.gtrends <- function(x, ...) {
   df <- x$interest_over_time
-  df$hits <- as.numeric(gsub('<','',df$hits))
+  df$hits <- if(typeof(df$hits) == 'character'){
+    as.numeric(gsub('<','',df$hits))
+    } else {
+    df$hits
+    }
 
   df$legend <- paste(df$keyword, " (", df$geo, ")", sep = "")
 

--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -216,6 +216,7 @@ gtrends <- function(
 #' }
 plot.gtrends <- function(x, ...) {
   df <- x$interest_over_time
+  df$hits <- as.numeric(gsub('<','',df$hits))
 
   df$legend <- paste(df$keyword, " (", df$geo, ")", sep = "")
 


### PR DESCRIPTION
When relative search interest is less than 1, the hits column returns "<1" and changes the data type to `chr`. The resulting output of `plot.gtrends` ends up failing. This change (line 219) removes the '<' and ensures the column is numeric when plotting without altering the actual `gtrends` object.