### PR TITLE
Widget-Download:  Characters like + are not encoded properly in the keyword

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# gtrendsR 1.4.4
+- Added the possibility to use search operators like "+" and "-"
+
 # gtrendsR 1.4.3
 
 - Added more options to specify time interval of the search (#289). @JBleher

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # gtrendsR (development version)
+- Added the possibility to use search operators like "+" and "-"
 
 # gtrendsR 1.4.4
-- Added the possibility to use search operators like "+" and "-"
 - Dates are parsed correctly when `time = "all"` (#309). @JBleher
 
 # gtrendsR 1.4.3

--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -194,7 +194,7 @@ gtrends <- function(
   if(!onlyInterest){
     interest_by_region <- interest_by_region(widget, comparison_item, low_search_volume,tz)
     related_topics <- related_topics(widget, comparison_item, hl,tz)
-    related_queries <- related_queries(widget, comparison_item,tz)
+    related_queries <- related_queries(widget, comparison_item,tz,hl)
     res <- list(
       interest_over_time = interest_over_time,
       interest_by_country = do.call(rbind, interest_by_region[names(interest_by_region) == "country"]),

--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -181,7 +181,13 @@ gtrends <- function(
   # ****************************************************************************
   # Request a token from Google
   # ****************************************************************************
-  comparison_item <- data.frame(geo, time,keyword, stringsAsFactors = FALSE)
+  keyword <- sapply(keyword,function(x){
+    y <- gsub("[+]","%2B",x)
+    z <- gsub(" ","+",y)
+    return(z)
+    })
+  names(keyword) <- NULL
+  comparison_item <- data.frame(keyword,geo,time, stringsAsFactors = FALSE)
 
   widget <- get_widget(comparison_item, category, gprop, hl, cookie_url,tz)
 

--- a/R/related_queries.R
+++ b/R/related_queries.R
@@ -86,11 +86,16 @@ create_related_queries_payload <- function(i, widget,tz,hl) {
   res <- rbind(top, rising)
   res$id <- NULL
   res$geo <- unlist(payload2$restriction$geo, use.names = FALSE)
-  if(is.na(widget$request$restriction$complexKeywordsRestriction$operator[[i]])){
-    res$keyword <- widget$request$restriction$complexKeywordsRestriction$keyword[[i]]$value
+  if(length(widget$request$restriction$complexKeywordsRestriction$operator)!=0){
+    if(is.na(widget$request$restriction$complexKeywordsRestriction$operator[[i]])){
+      res$keyword <- widget$request$restriction$complexKeywordsRestriction$keyword[[i]]$value
+    }else{
+      res$keyword <- paste(widget$request$restriction$complexKeywordsRestriction$keyword[[i]]$value,collapse="+")
+    }
   }else{
-    res$keyword <- paste(widget$request$restriction$complexKeywordsRestriction$keyword[[i]]$value,collapse="+")
+    res$keyword <- widget$request$restriction$complexKeywordsRestriction$keyword[[i]]$value
   }
+  
   
   res$category <- payload2$requestOptions$category
 

--- a/R/related_queries.R
+++ b/R/related_queries.R
@@ -86,7 +86,12 @@ create_related_queries_payload <- function(i, widget,tz,hl) {
   res <- rbind(top, rising)
   res$id <- NULL
   res$geo <- unlist(payload2$restriction$geo, use.names = FALSE)
-  res$keyword <- payload2$restriction$complexKeywordsRestriction$keyword$value
+  if(is.na(widget$request$restriction$complexKeywordsRestriction$operator[[i]])){
+    res$keyword <- widget$request$restriction$complexKeywordsRestriction$keyword[[i]]$value
+  }else{
+    res$keyword <- paste(widget$request$restriction$complexKeywordsRestriction$keyword[[i]]$value,collapse="+")
+  }
+  
   res$category <- payload2$requestOptions$category
 
   return(res)

--- a/R/related_topics.R
+++ b/R/related_topics.R
@@ -80,7 +80,15 @@ create_related_topics_payload <- function(i, widget, hl,tz) {
   res <- rbind(top, rising)
   res$id <- NULL
   res$geo <- unlist(payload2$restriction$geo, use.names = FALSE)
-  res$keyword <- payload2$restriction$complexKeywordsRestriction$keyword$value
+  if(length(widget$request$restriction$complexKeywordsRestriction$operator)!=0){
+    if(is.na(widget$request$restriction$complexKeywordsRestriction$operator[[i]])){
+      res$keyword <- widget$request$restriction$complexKeywordsRestriction$keyword[[i]]$value
+    }else{
+      res$keyword <- paste(widget$request$restriction$complexKeywordsRestriction$keyword[[i]]$value,collapse="+")
+    }
+  }else{
+    res$keyword <- widget$request$restriction$complexKeywordsRestriction$keyword[[i]]$value
+  }
   res$category <- payload2$requestOptions$category
 
   return(res)

--- a/R/related_topics.R
+++ b/R/related_topics.R
@@ -14,6 +14,7 @@ create_related_topics_payload <- function(i, widget, hl,tz) {
   payload2$restriction$time <- widget$request$restriction$time[[i]]
   payload2$restriction$originalTimeRangeForExploreUrl <- widget$request$restriction$originalTimeRangeForExploreUrl[[i]]
   payload2$restriction$complexKeywordsRestriction$keyword <- widget$request$restriction$complexKeywordsRestriction$keyword[[i]]
+  payload2$restriction$complexKeywordsRestriction$operator <- widget$request$restriction$complexKeywordsRestriction$operator[[i]]
   payload2$keywordType <- widget$request$keywordType[[i]]
   payload2$metric <- widget$request$metric[[i]]
   payload2$trendinessSettings$compareTime <- widget$request$trendinessSettings$compareTime[[i]]
@@ -22,15 +23,13 @@ create_related_topics_payload <- function(i, widget, hl,tz) {
   payload2$requestOptions$category <- widget$request$requestOptions$category[[i]]
   payload2$language <- widget$request$language[[i]]
 
-  url <- URLencode(paste0(
-    "https://trends.google.com/trends/api/widgetdata/relatedsearches/csv?req=",
-    # "https://www.google.com/trends/api/widgetdata/relatedsearches/csv?req=",
-    jsonlite::toJSON(payload2, auto_unbox = T),
-    "&token=", widget$token[i],
-    "&tz=",tz,"&hl=", hl
-  ))
+  url <- paste0(URLencode("https://www.google.com/trends/api/widgetdata/relatedsearches/csv?req="),
+                URLencode(paste0(jsonlite::toJSON(payload2, auto_unbox = TRUE)),reserved=TRUE),
+                URLencode(paste0("&token=", widget$token[i])),
+                URLencode(paste0("&tz=",tz,"&hl=",hl))
+  )
 
-  url <- encode_keyword(url)
+ # url <- encode_keyword(url)
   # VY. use the handler with proxy options.
   res <- curl::curl_fetch_memory(url, handle = .pkgenv[["cookie_handler"]])
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -80,19 +80,19 @@ check_time <- function(time_ranges) {
 
 get_widget <- function(comparison_item, category, gprop, hl, cookie_url, tz) {
   token_payload <- list()
+  #comparison_item$keyword <- gsub(pattern="\\+",replacement="%2B",comparison_item$keyword)
   token_payload$comparisonItem <- comparison_item
   token_payload$category <- category
   token_payload$property <- gprop
 
   # token_payload$comparisonItem$keyword <- curl::curl_escape(token_payload$comparisonItem$keyword)
   
-  url <- URLencode(paste0(
-    "https://www.google.com/trends/api/explore?property=&req=",
-    jsonlite::toJSON(token_payload, auto_unbox = TRUE),
-    "&tz=",tz,"&hl=", hl
-  ))
+  url <- paste0(URLencode("https://www.google.com/trends/api/explore?property=&req="),
+                URLencode(paste0(jsonlite::toJSON(token_payload, auto_unbox = TRUE)),reserved=T),
+                URLencode(paste0("&tz=",tz,"&hl=", hl))
+  )
   
-  url <- encode_keyword(url)
+  #url <- encode_keyword(url)
   
   # if cookie_handler hasn't been set up, get the requisite cookies from Google's API
   if(!exists("cookie_handler", envir = .pkgenv)){ get_api_cookies(cookie_url) }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -130,12 +130,16 @@ interest_over_time <- function(widget, comparison_item,tz) {
     payload2$requestOptions$category <- widget$request$requestOptions$category[2]
     token_payload2 <- widget$token[which(widget$id == "TIMESERIES")]
 
-    url <- URLencode(paste0(
-      "https://www.google.com/trends/api/widgetdata/multirange/csv?req=",
-      jsonlite::toJSON(payload2, auto_unbox = T,null="list"),
-      "&token=", token_payload2,
-      "&tz=",tz
-    ))
+    
+    url <- paste0(URLencode("https://www.google.com/trends/api/widgetdata/multirange/csv?req="),
+                  URLencode(jsonlite::toJSON(payload2, auto_unbox = T,null="list"),reserved = TRUE),
+                  URLencode(paste0("&token=", token_payload2,"&tz=",tz)))
+    # url <- URLencode(paste0(
+    #   "https://www.google.com/trends/api/widgetdata/multirange/csv?req=",
+    #   jsonlite::toJSON(payload2, auto_unbox = T,null="list"),
+    #   "&token=", token_payload2,
+    #   "&tz=",tz
+    # ))
   }else{
     if(!is.na(widget$request$locale[1])|(length(unique(unlist(widget$request$comparisonItem[[1]]$geo)))>1)){
       payload2$locale <- widget$request$locale[1]
@@ -156,18 +160,15 @@ interest_over_time <- function(widget, comparison_item,tz) {
       payload2$requestOptions$property <- widget$request$requestOptions$property[2]
       token_payload2 <- widget$token[2]
     }
-    url <- URLencode(paste0(
-      "https://www.google.com/trends/api/widgetdata/multiline/csv?req=",
-      jsonlite::toJSON(payload2, auto_unbox = T),
-      "&token=", token_payload2,
-      "&tz=",tz
-    ))
+    url <- paste0(URLencode("https://www.google.com/trends/api/widgetdata/multiline/csv?req="),
+                  URLencode(jsonlite::toJSON(payload2, auto_unbox = T,null="list"),reserved = TRUE),
+                  URLencode(paste0("&token=", token_payload2,"&tz=",tz)))
   }
 
   # ****************************************************************************
   # Downoad the results
   # ****************************************************************************
-  url <- encode_keyword(url)
+  #url <- encode_keyword(url)
   
   # VY. use the handler with proxy options.
   res <- curl::curl_fetch_memory(url, handle = .pkgenv[["cookie_handler"]])
@@ -358,14 +359,18 @@ create_geo_payload <- function(i, widget, resolution, low_search_volume,tz) {
   payload2$includeLowSearchVolumeGeos <- low_search_volume
 
 
-  url <- URLencode(paste0(
-    "https://www.google.com/trends/api/widgetdata/comparedgeo/csv?req=",
-    jsonlite::toJSON(payload2, auto_unbox = T,null="list"),
-    "&token=", widget$token[i],
-    "&tz=",tz,"&hl=en-US"
-  ))
+  url <- paste0(URLencode("https://www.google.com/trends/api/widgetdata/comparedgeo/csv?req="),
+                URLencode(jsonlite::toJSON(payload2, auto_unbox = T,null="list"),reserved = TRUE),
+                URLencode(paste0("&token=",widget$token[i],"&tz=",tz,"&hl=en-US")))
+  
+  # url <- URLencode(paste0(
+  #   "https://www.google.com/trends/api/widgetdata/comparedgeo/csv?req=",
+  #   jsonlite::toJSON(payload2, auto_unbox = T,null="list"),
+  #   "&token=", widget$token[i],
+  #   "&tz=",tz,"&hl=en-US"
+  # ))
 
-  url <- encode_keyword(url)
+  # url <- encode_keyword(url)
   # VY. use the handler with proxy options.
   res <- curl::curl_fetch_memory(url, handle = .pkgenv[["cookie_handler"]])
 
@@ -391,9 +396,15 @@ create_geo_payload <- function(i, widget, resolution, low_search_volume,tz) {
     timevar = "temp",
     times = names(df)[2:ncol(df)]
   )
+  if(length(widget$request$comparisonItem[[i]]$complexKeywordsRestriction$operator)==0){
+    kw <- do.call(rbind, widget$request$comparisonItem[[i]]$complexKeywordsRestriction$keyword)
+  }else{
+    value <- paste(widget$request$comparisonItem[[i]]$complexKeywordsRestriction$keyword[[1]]$value,collapse=" + ")
+    type <- unique(widget$request$comparisonItem[[i]]$complexKeywordsRestriction$keyword[[1]]$type)
+    kw <- data.frame(type=type,value=value)
+  }
 
-
-  kw <- do.call(rbind, widget$request$comparisonItem[[i]]$complexKeywordsRestriction$keyword)
+  #kw <- do.call(rbind, widget$request$comparisonItem[[i]]$complexKeywordsRestriction$keyword)
 
   df <- cbind(
     df,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -80,15 +80,12 @@ check_time <- function(time_ranges) {
 
 get_widget <- function(comparison_item, category, gprop, hl, cookie_url, tz) {
   token_payload <- list()
-  #comparison_item$keyword <- gsub(pattern="\\+",replacement="%2B",comparison_item$keyword)
   token_payload$comparisonItem <- comparison_item
   token_payload$category <- category
   token_payload$property <- gprop
-
-  # token_payload$comparisonItem$keyword <- curl::curl_escape(token_payload$comparisonItem$keyword)
   
   url <- paste0(URLencode("https://www.google.com/trends/api/explore?property=&req="),
-                URLencode(paste0(jsonlite::toJSON(token_payload, auto_unbox = TRUE)),reserved=T),
+                URLencode(paste0(jsonlite::toJSON(token_payload, auto_unbox = TRUE)),reserved=TRUE),
                 URLencode(paste0("&tz=",tz,"&hl=", hl))
   )
   


### PR DESCRIPTION
Now you can do stuff like this:
https://support.google.com/trends/answer/4359582?hl=en

I commented the url_encode function, since I do not know why it is there... I think it shouldn't... but please tell me...

best, jb