### PR TITLE
switch Travis CI to R 4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 # Run Travis CI for R using https://eddelbuettel.github.io/r-travis/
 
 language: c
-
 sudo: required
+dist: bionic
 
-dist: trusty
+jobs:
+  include:
+    - name: r-4.0
+      env: R_VERSION="4.0"
 
 before_install:
   - curl -OLs https://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gtrendsR (development version)
 
+- Switch Travis CI to R 4.0.0, use bionic as base
+
 # gtrendsR 1.4.6
 
 - Fix an issue when there was no "rising" data returned for the related topics. Some tests were failing due to this issue and causing errors on CRAN (#347).


### PR DESCRIPTION
Well done on fixing that other bug so quickly!  

Here is just a minor update based on work I was doing this weekend to update the r-travis `run.sh` script to use R 4.0.0.  Already tested / used in three other repos and should be ready.  

The underlying script is still driven a variable `R_VERSION` that still defaults to 3.5 to not (yet, at least) force all repos over, and here we opt in with an explicit 4.0.  Hope its transparent.  