### PR TITLE
this opts out of all four test files unless opted in

### DIFF
--- a/inst/tinytest/test_encoding_does_not_change.R
+++ b/inst/tinytest/test_encoding_does_not_change.R
@@ -11,6 +11,11 @@ if (!curl::has_internet()) {
   exit_file("Skipping tests for lack of internet.")
 }
 
+# Exit unless opted in
+if (Sys.getenv("RunAllGtrendsRTests", unset="") == "") {
+    exit_file("Skipping tests not opted into.")
+}
+
 # Japanese
 kw <- "赤"
 res <- gtrends(kw)

--- a/inst/tinytest/test_gprop.R
+++ b/inst/tinytest/test_gprop.R
@@ -3,6 +3,11 @@ if (!curl::has_internet()) {
   exit_file("Skipping tests for lack of internet.")
 }
 
+# Exit unless opted in
+if (Sys.getenv("RunAllGtrendsRTests", unset="") == "") {
+    exit_file("Skipping tests not opted into.")
+}
+
 kw <- "news"
 
 res <- gtrends(kw, gprop = "web")

--- a/inst/tinytest/test_not_empty_results.R
+++ b/inst/tinytest/test_not_empty_results.R
@@ -3,6 +3,11 @@ if (!curl::has_internet()) {
   exit_file("Skipping tests for lack of internet.")
 }
 
+# Exit unless opted in
+if (Sys.getenv("RunAllGtrendsRTests", unset="") == "") {
+    exit_file("Skipping tests not opted into.")
+}
+
 # Single keyword ----------------------------------------------------------
 
 kw <- "news"

--- a/inst/tinytest/test_timespans.R
+++ b/inst/tinytest/test_timespans.R
@@ -3,6 +3,11 @@ if (!curl::has_internet()) {
   exit_file("Skipping tests for lack of internet.")
 }
 
+# Exit unless opted in
+if (Sys.getenv("RunAllGtrendsRTests", unset="") == "") {
+    exit_file("Skipping tests not opted into.")
+}
+
 kw <- "news"
 
 res <- gtrends(kw, time = "now 1-H")


### PR DESCRIPTION
This PR is a little radical in that all tests are now conditional on being explicitly opted in via a new environment variable.

This may help at CRAN.  The `curl` issue seems random _and even hit me here_ but was easily fixed by a re-run.  This may be an issue in `curl`, seen "randomly" at at least the CRAN Debian machine and here under ubuntu-latest.

I am wondering if you should add a simple "lighter" unit test file with _something_ not involving a `curl` call so that we always have "something" to run?

Also, if you merge the previous PR I can rebase it in here so that this PR gets the benefit of the tests.