### PR TITLE
Refresh ci.yaml to current standard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ on:
   pull_request:
 
 env:
-  USE_BSPM: "true"
   _R_CHECK_FORCE_SUGGESTS_: "false"
 
 jobs:
@@ -21,13 +20,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
-      - name: Bootstrap
-        run: |
-          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
-          chmod 0755 run.sh
-          ./run.sh bootstrap
+      - name: Setup
+        uses: eddelbuettel/github-actions/r-ci@master
 
       - name: Dependencies
         run: ./run.sh install_all


### PR DESCRIPTION
This is a fairly low-key and 'procedural' PR.  I tend to roll my uses to `ci.yaml` to the current (upstream) action(s), here just checkout.  I also noticed that this version was still using an older (more verbose) form, we can now be a bit more compact by relying on a helper action I wrote (and use a lot); this also allows us to remove a (now implicit) environment variable.

No functionality changes.